### PR TITLE
Fixes Watch Task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -52,8 +52,8 @@ gulp.task('images', function () {
 });
 
 gulp.task('watch', function () {
-  gulp.watch('dist/scss/**/*.scss', ['sass']);
-  gulp.watch('dist/js/**/*.js', ['js']);
+  gulp.watch('src/scss/**/*.scss', ['sass']);
+  gulp.watch('src/js/**/*.js', ['js']);
   gulp.watch('./*.html').on('change', browserSync.reload);
 });
 


### PR DESCRIPTION
Watch task should watch the source directory for changes. It
currently watches the compiled directory and the tasks never
get triggered.